### PR TITLE
Simplified the reflex binary installation

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,9 +1,6 @@
 FROM golang:1.9.1-alpine3.6
 ENV GOBINARIES /go/bin
-ENV REFLEXURL=http://s3.amazonaws.com/wbm-raff/bin/reflex1.9b2 REFLEXSHA=870b86b5ba1b91a9610a9ea7b0c894294f0ff45be2f7a4604c9846df36720a1d
 WORKDIR $GOBINARIES
-RUN apk add --update tini curl gcc musl-dev && rm -rf /var/cache/apk/* &&\
-    echo 'hosts: files [NOTFOUND=return] dns' >> /etc/nsswitch.conf &&\
-    wget -q "$REFLEXURL" -O reflex &&\
-    echo "$REFLEXSHA  reflex" | sha256sum -c &&\
-    chmod +x /go/bin/reflex
+RUN apk add --update tini curl gcc musl-dev git && rm -rf /var/cache/apk/* &&\
+    echo 'hosts: files [NOTFOUND=return] dns' >> /etc/nsswitch.conf
+RUN ["go","get","github.com/cespare/reflex"]


### PR DESCRIPTION
I recently realized that I should be running `go get` within the actual box itself instead of prebuilding the reflex binary and sticking it inside of the image.

PRO:
* An S3 Bucket is no longer needed to be maintained and a new binary doesn't need to be built every time a new version of Go comes out.

CON:
* It reflex ever changes, this will break everything immediately.
